### PR TITLE
Added functionality if weight == -1, always select

### DIFF
--- a/scripts/dDungeon/lootTables/rollLootTable_Category.dsc
+++ b/scripts/dDungeon/lootTables/rollLootTable_Category.dsc
@@ -43,13 +43,15 @@ dd_RollLootTable_Category:
             #Skip loot table keys that are loot table settings, not loot entries
             - if <[itemKey].starts_with[_]>:
                 - foreach next
+            - if <[itemKey.weight]> == -1:
+                - define lootTableItems <[lootTableItems].insert[<map[item_key=<[itemKey]>;target_weight=-1]>].at[1]>
             - define selectionTotalWeight:+:<[itemEntry.weight].if_null[<[weight]>]>
             - define lootTableItems:->:<map[item_key=<[itemKey]>;target_weight=<[selectionTotalWeight]>]>
 
         - define selectedValue <util.random.decimal[0.1].to[<[selectionTotalWeight]>]>
         - foreach <[lootTableItems]> as:itemEntry:
-            #If the selected value is below the target chance of the item then we have a winner!
-            - if <[itemEntry.target_weight]> >= <[selectedValue]>:
+            #If the selected value is below the target chance of the item or is -1 then we have a winner!
+            - if <[itemEntry.target_weight]> >= <[selectedValue]> || <[itemEntry.target_weight]> == -1:
                 - define itemData <[lootTable.<[itemEntry.item_key]>]>
                 #Get item name (remove any comments/details at end of name)
                 - define itemName <[itemEntry.item_key].before_last[#]>
@@ -124,6 +126,10 @@ dd_RollLootTable_Category:
                 #(Less than 0 is okay. -1 indicates no limit is set, so we can keep going.)
                 - if <[lootTable.<[itemEntry.item_key]>.max_selection_count].if_null[-1]> == 0:
                     - define lootTable.<[itemEntry.item_key]>:!
+
+                #If the item weight is -1, remove the item from the list.
+                - if <[itemEntry.weight]> == -1:
+                    - define <[lootTableItems]>:<-:<[itemEntry]>
 
                 #Stop this run of selecting an item
                 - foreach stop


### PR DESCRIPTION
If weight is -1, when rolling it will first grab
-1 weights, add them to returned, then remove from the list

Idk if you'll like this, but it took me a few minutes to implement. This functionality already exists, but only if you had the forethought to put in separate categories. In this case, I was thinking about putting cobwebs in certain types of chests, but the categories in question are so numerous it will take me a few hours to redo them, and I'm bound to miss a few. 