### PR TITLE
Dev -> Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Minecraft Dungeon Generation toolset using Denizen Scripting.
   - DungeonKey: Can be any value, this is just used to identify the dungeon between regenerating a world
 - /ddGoTo [DungeonKey]
   - Teleports the player to the configured Dungeon Entrance for the given Dungeon Key
-- /ddPaste [FileName]
+- /ddPaste
   - Paste a given Dungeon Section file at the player's current location
-  - FileName will fill in a tab-complete list of files
+  - A Clickable menu will open in chat to navigate to the Section to paste
 - /ddDestroy [DungeonKey]
   - Destroys a dungeon world for the given DungeonKey (matches the one used in /ddCreate)
 - /ddTestLootTable [LootTableName] [ReplaceInventoryLoot] [RepeatCount]

--- a/scripts/dDungeon/commands/pasteSchematic.dsc
+++ b/scripts/dDungeon/commands/pasteSchematic.dsc
@@ -19,20 +19,20 @@ dd_PasteSchematic_Select:
     #Missing category, show prompt for it
     - if !<[category].exists>:
         - narrate "<n><blue> *** Click Category to be pasted"
-        - foreach <util.list_files[schematics\dDungeon].alphabetical> as:fileCategory:
+        - foreach <util.list_files[schematics/dDungeon].alphabetical> as:fileCategory:
             - clickable dd_PasteSchematic_Select def.category:<[fileCategory]> for:<player> usages:1 until:5m save:clickable
             - narrate "<blue> * <gold>[<[fileCategory].on_click[<entry[clickable].command>]>]"
 
     #Missing type, show prompt for it
     - else if !<[type].exists>:
         - narrate "<n><blue> *** Click Type to be pasted"
-        - foreach <util.list_files[schematics\dDungeon\<[category]>].alphabetical> as:fileType:
+        - foreach <util.list_files[schematics/dDungeon/<[category]>].alphabetical> as:fileType:
             - clickable dd_PasteSchematic_Select def.category:<[category]> def.type:<[fileType]>  for:<player> usages:1 until:5m save:clickable
             - narrate "<blue> * <gold>[<[fileType].on_click[<entry[clickable].command>]>]"
     #Missing schematic name, prompt for it
     - else if !<[schematicName].exists>:
         - narrate "<n><blue> *** Click File to be pasted"
-        - foreach <util.list_files[schematics\dDungeon\<[category]>\<[type]>\].filter_tag[<[filter_value].ends_with[.schem]>].alphabetical> as:fileName:
+        - foreach <util.list_files[schematics/dDungeon/<[category]>/<[type]>/].filter_tag[<[filter_value].ends_with[.schem]>].alphabetical> as:fileName:
             - define fileName <[fileName].replace_text[.schem]>
             - clickable dd_PasteSchematic_Select def.category:<[category]> def.type:<[type]> def.schematicName:<[fileName]> for:<player> usages:1 until:5m save:clickable
             - narrate "<blue> * <gold>[<[fileName].on_click[<entry[clickable].command>]>]"

--- a/scripts/dDungeon/commands/pasteSchematic.dsc
+++ b/scripts/dDungeon/commands/pasteSchematic.dsc
@@ -8,31 +8,40 @@ dd_PasteSchematicCommand:
     - placeSchematic
     permission: ops
     permission message: <bold><red>*** You're not authorized to do that ***
-    tab complete:
-    - define input <context.raw_args.replace_text[\].with[/]>
-    - if <[input].ends_with[/]>:
-        - define input <[input].before_last[/]>
-    - define tmp <util.list_files[schematics/<[input]>].if_null[<list[]>]>
-    - if <[tmp].is_empty>:
-        - define files <player.flag[dd_pasteSchematicList].if_null[<list[]>]>
-    - else:
-        - define files <list[]>
-        - foreach <[tmp]> as:file:
-            - if <[file].starts_with[_]>:
-                - foreach next
-            - define files:->:<[input]>/<[file]>
-        - flag <player> dd_pasteSchematicList:<[files]> expire:30s
-
-    - foreach <[files]> as:file:
-        - if !<[file].advanced_matches[<[input]>*]> || <[file].ends_with[.yml]>:
-            - define files:<-:<[file]>
-    - determine <[files]>
     script:
-    - define input <context.raw_args.replace_text[\].with[/]>
-    - define input <[input].replace_text[.schem]>
-    - define input <[input].replace_text[/schematics/]>
-    - ~schematic load name:<[input]> filename:<[input]>
-    - ~schematic paste name:<[input]> <player.location> entities delayed max_delay_ms:25
-    - ~schematic unload name:<[input]>
-    - narrate "<blue><italic> *** Pasted Schematic"
-    - ~run dd_ShowSectionBlocks_Player def.user:<player>
+    - run dd_PasteSchematic_Select
+
+dd_PasteSchematic_Select:
+    debug: false
+    type: task
+    definitions: category|type|schematicName
+    script:
+    #Missing category, show prompt for it
+    - if !<[category].exists>:
+        - narrate "<n><blue> *** Click Category to be pasted"
+        - foreach <util.list_files[schematics\dDungeon].alphabetical> as:fileCategory:
+            - clickable dd_PasteSchematic_Select def.category:<[fileCategory]> for:<player> usages:1 until:5m save:clickable
+            - narrate "<blue> * <gold>[<[fileCategory].on_click[<entry[clickable].command>]>]"
+
+    #Missing type, show prompt for it
+    - else if !<[type].exists>:
+        - narrate "<n><blue> *** Click Type to be pasted"
+        - foreach <util.list_files[schematics\dDungeon\<[category]>].alphabetical> as:fileType:
+            - clickable dd_PasteSchematic_Select def.category:<[category]> def.type:<[fileType]>  for:<player> usages:1 until:5m save:clickable
+            - narrate "<blue> * <gold>[<[fileType].on_click[<entry[clickable].command>]>]"
+    #Missing schematic name, prompt for it
+    - else if !<[schematicName].exists>:
+        - narrate "<n><blue> *** Click File to be pasted"
+        - foreach <util.list_files[schematics\dDungeon\<[category]>\<[type]>\].filter_tag[<[filter_value].ends_with[.schem]>].alphabetical> as:fileName:
+            - define fileName <[fileName].replace_text[.schem]>
+            - clickable dd_PasteSchematic_Select def.category:<[category]> def.type:<[type]> def.schematicName:<[fileName]> for:<player> usages:1 until:5m save:clickable
+            - narrate "<blue> * <gold>[<[fileName].on_click[<entry[clickable].command>]>]"
+    #Nothing missing, paste schematic
+    - else:
+        - define file dDungeon/<[category]>/<[type]>/<[schematicName]>
+        - define schemName ddTmp_<player.name>_pasteSchem
+        - ~schematic load name:<[schemName]> filename:<[file]>
+        - ~schematic paste name:<[schemName]> <player.location> entities delayed max_delay_ms:25
+        - ~schematic unload name:<[schemName]>
+        - narrate "<blue><italic> *** Pasted Schematic <[schematicName]> (Category: <[category]>) (Type: <[type]>)"
+        - ~run dd_ShowSectionBlocks_Player def.user:<player>

--- a/scripts/dDungeon/config/dDungeon.dsc
+++ b/scripts/dDungeon/config/dDungeon.dsc
@@ -1,0 +1,10 @@
+dd_Config:
+    debug: false
+    type: data
+    #Version number for dDungeon Scripts
+    #This will change as new updates are out of dev
+    dd_version: 1.0
+    #Version number for data format of saved Schematics.
+    #This should only change when there is a breaking data structure change for schematics. Should be RARE.
+    #Will be tagged to schematics as they are saved.
+    dd_schematic_data_version: 1.0

--- a/scripts/dDungeon/generation/breakdownWorld.dsc
+++ b/scripts/dDungeon/generation/breakdownWorld.dsc
@@ -9,7 +9,7 @@ dd_BreakdownWorld:
 
     #Teleport offline players that are in the dungeon
     - foreach <server.offline_players> as:player:
-        - if <[player].location.world> matches <[world]>:
+        - if <[player].location.world.if_null[null]> matches <[world]>:
             - ~run dd_ExitDungeon def.player:<[player]>
 
     #Remove all NPCs spawned into the world

--- a/scripts/dDungeon/generation/createDungeon.dsc
+++ b/scripts/dDungeon/generation/createDungeon.dsc
@@ -89,7 +89,6 @@ dd_Create:
     - flag <[loc]> dd_SectionOptions.readonly:true
     - ~run dd_Schematic_UndoOrientation def.schemPath:<[sectionName]> def.flip:<[flip]> def.rotation:0
 
-
     #Get area of pasted section, handle any post transforms
     - define cuboid <[loc].add[<[sectionOptions.pos1]>].to_cuboid[<[loc].add[<[sectionOptions.pos2]>]>]>
     - if <[dungeonSettings.noise_generation_task].exists>:
@@ -210,7 +209,7 @@ dd_Create:
     - announce "<gold> *** Total generation took <util.time_now.duration_since[<[startTime]>].formatted> "
 
 
-    - run dd_SectionDataCache_Unload def.world:<[world]>
+    - ~run dd_SectionDataCache_Unload def.world:<[world]>
     - note remove as:<[world].name>_dcarea
 
     - flag <[world]> dd_generationRunning:false

--- a/scripts/dDungeon/generation/processNextSection.dsc
+++ b/scripts/dDungeon/generation/processNextSection.dsc
@@ -185,9 +185,14 @@ dd_ProcessNextSection:
                         - ~schematic paste noair name:<[targetSectionSchemPath]> <[pasteLoc]> entities delayed
                         - ~run dd_Schematic_UndoOrientation def.schemPath:<[targetSectionSchemPath]> def.flip:<[flip]> def.rotation:<[rotate]>
 
+
                         #Flag options block with "transformed" section options data
                         - flag <[pasteLoc]> dd_SectionOptions:<[testOptions]>
                         - flag <[pasteLoc]> dd_SectionOptions.readonly:true
+
+                        #Reload any saved flags for the section due to flags being lost when pasting when saved to air blocks. Happens because we paste with noair set.
+                        - if !<[testOptions.flags].keys.is_empty.if_null[true]>:
+                            - ~run dd_ReloadSectionFlags def.optionsLoc:<[pasteLoc]>
 
                         #Remove this pathway from pathway options (since we just used it...)
                         - define testOptions.pathways.<[testPathwayKey]>:!

--- a/scripts/dDungeon/generation/transforms/flipOverX.dsc
+++ b/scripts/dDungeon/generation/transforms/flipOverX.dsc
@@ -55,5 +55,17 @@ dd_Transform_FlipOverX:
     - if <[sectionData.entrancePoint].exists>:
         - define sectionData.entrancePoint <[sectionData.entrancePoint].with_z[<[sectionData.entrancePoint].z.mul[-1]>]>
 
+    #Flip flags
+    - define flags <[sectionData.flags].if_null[<map[]>]>
+    - define newFlags <map[]>
+    - foreach <[flags]> as:flags_map key:flag_offset:
+        #Flip flag offset
+        - define flagOffsetLoc <[flag_offset].proc[dd_keytolocation]>
+        - define newFlagOffset <[flagOffsetLoc].with_z[<[flagOffsetLoc].z.mul[-1]>].proc[dd_LocationToKey]>
+        #Save flag definition
+        - define newFlags.<[newFlagOffset]> <[flags_map]>
+    #Save new flags data
+    - define sectionData.flags <[newFlags]>
+
     #Return new section data
     - determine <[sectionData]>

--- a/scripts/dDungeon/generation/transforms/rotate.dsc
+++ b/scripts/dDungeon/generation/transforms/rotate.dsc
@@ -55,5 +55,16 @@ dd_Transform_RotateAroundY:
     - define pos <[pos].rotate_around_y[<[rotRad]>].round>
     - define sectionData.pos2 <[pos]>
 
+    #Flip flags
+    - define flags <[sectionData.flags].if_null[<map[]>]>
+    - define newFlags <map[]>
+    - foreach <[flags]> as:flags_map key:flag_offset:
+        #Rotate invKey
+        - define newFlagOffset <[flag_offset].proc[dd_KeyToLocation].rotate_around_y[<[rotRad]>].proc[dd_LocationToKey]>
+        #Save flag definition
+        - define newFlags.<[newFlagOffset]> <[flags_map]>
+    #Save new flags data
+    - define sectionData.flags <[newFlags]>
+
     #Return new section data
     - determine <[sectionData]>

--- a/scripts/dDungeon/generation/utils/reloadSectionFlags.dsc
+++ b/scripts/dDungeon/generation/utils/reloadSectionFlags.dsc
@@ -1,0 +1,10 @@
+dd_ReloadSectionFlags:
+    debug: false
+    type: task
+    definitions: optionsLoc
+    script:
+    - define sectionOptions <[optionsLoc].flag[dd_SectionOptions]>
+    - foreach <[sectionOptions.flags].if_null[<map[]>]> as:offsetData key:offset:
+        - foreach <[offsetData].if_null[<map[]>]> as:flag_data key:flag_name:
+            - define flagLoc <[optionsLoc].add[<[offset]>]>
+            - flag <[flagLoc]> <[flag_name]>:<[flag_data]>

--- a/scripts/dDungeon/tools/schematicEditor.dsc
+++ b/scripts/dDungeon/tools/schematicEditor.dsc
@@ -110,7 +110,7 @@ dd_SchematicEditor_MainMenu:
 
             - clickable dd_SchematicEditor_SetDungeonExitRadius def.optionsLoc:<[optionsLoc]> def.clickableGroupId:<[clickableGroupId]> for:<player> usages:1 until:5m save:clickSetExitRadius
             - run dd_Clickable_AddToGroup def.groupId:<[clickableGroupId]> def.clickableId:<entry[clickSetExitRadius].id>
-            - narrate "<blue>4.2: Set Spawn Room's Exit Radius <gold>[<element[SET].on_click[<entry[clickSetExitRadius].command>].on_hover[<script.data_key[data.hint_SetExitRadius].parsed>]>]"
+            - narrate "<blue>4.2: Set Spawn Room's Exit Radius (Current: <[sectionData.exitRadius].if_null[ERROR]>) <gold>[<element[SET].on_click[<entry[clickSetExitRadius].command>].on_hover[<script.data_key[data.hint_SetExitRadius].parsed>]>]"
 
         - clickable dd_SchematicEditor_SetSchematicName def.optionsLoc:<[optionsLoc]> def.clickableGroupId:<[clickableGroupId]> def.returnToMainMenu:true for:<player> usages:1 until:5m save:clickSetName
         - run dd_Clickable_AddToGroup def.groupId:<[clickableGroupId]> def.clickableId:<entry[clickSetName].id>

--- a/scripts/dDungeon/tools/tool_schematicCreator/saveSchematic.dsc
+++ b/scripts/dDungeon/tools/tool_schematicCreator/saveSchematic.dsc
@@ -22,12 +22,12 @@ dd_SchematicEditor_SaveSchematic:
     - define cuboid <[pos1].to_cuboid[<[pos2]>]>
 
     - ~schematic create name:<[name]> location:<[optionsLoc]> area:<[cuboid]> entities flags
-    - ~schematic save name:<[name]> filename:dDungeon\<[category]>\<[type]>\<[name]>
+    - ~schematic save name:<[name]> filename:dDungeon/<[category]>/<[type]>/<[name]>
     - ~schematic unload name:<[name]>
 
     - yaml create id:tmp_options
     - yaml id:tmp_options set SectionOptions:<[optionsBlockData]>
-    - ~yaml savefile:schematics\dDungeon\<[category]>\<[type]>\<[name]>.yml id:tmp_options
+    - ~yaml savefile:schematics/dDungeon/<[category]>/<[type]>/<[name]>.yml id:tmp_options
     - yaml unload id:tmp_options
 
     - narrate "<blue><italic> *** Schematic <gold><[name]> <blue>Saved"

--- a/scripts/dDungeon/tools/tool_schematicCreator/saveSchematic.dsc
+++ b/scripts/dDungeon/tools/tool_schematicCreator/saveSchematic.dsc
@@ -7,6 +7,7 @@ dd_SchematicEditor_SaveSchematic:
         - run dd_Clickable_CancelGroup def.groupId:<[clickableGroupId]>
 
     - define optionsBlockData <[optionsLoc].flag[dd_SectionOptions]>
+    - define optionsBlockData.schematic_data_version <script[dd_Config].data_key[dd_schematic_data_version]>
 
     - if <[optionsBlockData.readonly].if_null[false]>:
         - narrate "<red> *** Whoah!! It looks like you're trying to save a Dungeon Section that was generated as part of a Dungeon."

--- a/scripts/dDungeon/tools/tool_schematicCreator/setDungeonEntranceRadius.dsc
+++ b/scripts/dDungeon/tools/tool_schematicCreator/setDungeonEntranceRadius.dsc
@@ -1,14 +1,14 @@
 dd_SchematicEditor_SetDungeonExitRadius:
     debug: false
     type: task
-    definitions: loc|clickableGroupId
+    definitions: optionsLoc|clickableGroupId
     script:
     #Cancel out clickable group if one is set
     - if <[clickableGroupId].if_null[no_value]> != no_value:
         - run dd_Clickable_CancelGroup def.groupId:<[clickableGroupId]>
 
     - narrate "<n><blue><italic> *** Enter an integer value for this Spawn Room's Exit Radius. Players entering this radius from the Entrance Point will leave the dungeon."
-    - flag <player> dd_SchematicEditor_SetDungeonExitRadius:<[loc]> expire:1m
+    - flag <player> dd_SchematicEditor_SetDungeonExitRadius:<[optionsLoc]> expire:1m
 
 
 dd_SchematicEditor_SetDungeonExitRadius_Events:
@@ -16,7 +16,7 @@ dd_SchematicEditor_SetDungeonExitRadius_Events:
     type: world
     events:
         on player chats flagged:dd_SchematicEditor_SetDungeonExitRadius:
-        - define loc <player.flag[dd_SchematicEditor_SetDungeonExitRadius]>
+        - define optionsLoc <player.flag[dd_SchematicEditor_SetDungeonExitRadius]>
         - define value <context.message>
         - determine cancelled passively
 
@@ -25,8 +25,8 @@ dd_SchematicEditor_SetDungeonExitRadius_Events:
             - narrate "<red><italic> *** Spawn Room's Exit Radius value must be an integer or decimal <reset><red>(Value: <[value]>)"
         - else:
             - flag <player> dd_SchematicEditor_SetDungeonExitRadius:!
-            - flag <[loc]> dd_SectionOptions.exitRadius:<[value]>
+            - flag <[optionsLoc]> dd_SectionOptions.exitRadius:<[value]>
 
         - narrate "<blue><italic> *** Spawn Room's Exit Radius Set: <reset><gold><[value]>"
         - wait 10t
-        - run dd_SchematicEditor_MainMenu def.loc:<[loc]>
+        - run dd_SchematicEditor_MainMenu def.optionsLoc:<[optionsLoc]>


### PR DESCRIPTION
**Main Changes**
- /ddPaste command no longer takes a file path. Running command gives a clickable menu to select schematic.
- Fix for file paths being borked on Linux OS Distros.
- Fix for Schematic Editor breaking when setting exit radius.
- Flagged air blocks are now copied appropriately to the generated dungeon.
- Start tracking scripts version and schematic data version in dDungeon config.